### PR TITLE
docs: js and HTML ramp-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,4 +172,5 @@
 - [x] [Collaboration](./contribution-guidelines/collaboration) (merge from upfronIO/guides)
 - [x] [Git](./contribution-guidelines/git) (merge from upfronIO/guides)
 - [x] [Npm](./contribution-guidelines/npm) (merge from upfronIO/guides)
+- [x] [Ramp-up](./contribution-guidelines/ramp-up) (merge from upfronIO/guides)
 - [x] [Style guides](./contribution-guidelines/style-guides) (merge from upfronIO/guides)

--- a/contribution-guidelines/ramp-up/html.md
+++ b/contribution-guidelines/ramp-up/html.md
@@ -1,0 +1,11 @@
+# HTML
+
+#### References
+
+- [HTML Spec](https://html.spec.whatwg.org/multipage/)
+- [Document Object Model](https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model)
+
+
+#### Articles
+
+- [HTML Content categories](https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Content_categories)

--- a/contribution-guidelines/ramp-up/javascript.md
+++ b/contribution-guidelines/ramp-up/javascript.md
@@ -1,0 +1,39 @@
+# Javascript
+
+#### The Core
+
+- [JavaScript. The core.](http://dmitrysoshnikov.com/ecmascript/javascript-the-core/)
+
+
+#### ECMA-262-3 in detail:
+
+- [Chapter 1. Execution Contexts](http://dmitrysoshnikov.com/ecmascript/chapter-1-execution-contexts/)
+- [Chapter 2. Variable object](http://dmitrysoshnikov.com/ecmascript/chapter-2-variable-object/)
+- [Chapter 3. This](http://dmitrysoshnikov.com/ecmascript/chapter-3-this/)
+- [Chapter 4. Scope chain](http://dmitrysoshnikov.com/ecmascript/chapter-4-scope-chain/)
+- [Chapter 5. Functions](http://dmitrysoshnikov.com/ecmascript/chapter-5-functions/)
+- [Chapter 6. Closures](http://dmitrysoshnikov.com/ecmascript/chapter-6-closures/)
+- [The quiz](http://dmitrysoshnikov.com/ecmascript/the-quiz/)
+
+
+#### ECMA-262-5
+
+- [Chapter 0. Introduction](http://dmitrysoshnikov.com/ecmascript/es5-chapter-0-introduction/)
+- [Chapter 1. Properties and Property Descriptors](http://dmitrysoshnikov.com/ecmascript/es5-chapter-1-properties-and-property-descriptors/)
+- [Chapter 2. Strict Mode](http://dmitrysoshnikov.com/ecmascript/es5-chapter-2-strict-mode/)
+
+
+#### Promises
+
+- [Promises/A+ Standard](https://promisesaplus.com/)
+- [Article: We have a promblem with promises](http://pouchdb.com/2015/05/18/we-have-a-problem-with-promises.html)
+
+
+#### Further Reading
+
+- [Essential Javascript Links](https://github.com/ericelliott/essential-javascript-links#essential-javascript-links)  
+  > This is a very exclusive collection of only must-have JavaScript links. I'm only listing my favorite links. Nothing else makes the cut.
+- [Awesome NodeJS](https://github.com/sindresorhus/awesome-nodejs)  
+  A curated list of delightful Node.js packages and resources.
+- [Awesome Javascript](https://github.com/sorrycc/awesome-javascript)  
+  A collection of awesome browser-side JavaScript libraries, resources and shiny things.


### PR DESCRIPTION
@peyerluk This was a PR on the now gone upfrontIO/guides. All the content of that repo is now in this one.