### PR TITLE
fix(server-extensions): rework include documentation

### DIFF
--- a/reference-docs/server-extensions/add-custom-include.md
+++ b/reference-docs/server-extensions/add-custom-include.md
@@ -1,6 +1,6 @@
 ## Includes
 
-Think of Livingdocs includes as edge-side includes. You can create include components in your design, using a include [directive](../../livingdocs-framework/directives.md).
+Think of Livingdocs includes as edge-side includes. You can create include components in your design, using an include [directive](../../livingdocs-framework/directives.md).
 Includes can render content to your article or page that comes from an external source.
 Includes are resolved every time a document is rendered. So they can be used to
 display dynamic content that changes after a document has been published.
@@ -8,12 +8,12 @@ display dynamic content that changes after a document has been published.
 Displaying a teaser for example can be achieved through includes. An article is referenced and its data (eg. title, description, teaser image) is fetched when rendering a page.
 
 
-## A component with an include directive
+## A component with an include directive
 
 Includes are directives on components. They can be used as content placeholders
 that will be filled with HTML created by an include service on the server.
 
-An example component with an include diretive:
+An example component, defined in the design, with an include directive:
 ```html
 <script type="ld-conf">
   {
@@ -43,7 +43,7 @@ the rendering of the document.
 An unresolved include looks like this:
 ```html
 <div>
-  <ld-include data-include-service="embed-teaser" data-include-params="{"mediaId":2}"></ld-include>
+  <ld-include data-include-service="embed-teaser" data-include-params="{&quot;mediaId&quot;:2}"></ld-include>
 </div>
 ```
 
@@ -126,22 +126,21 @@ module.exports = {
   server: {
     type: 'function',
     function: function (params, options, callback) {
-      if (options && options.preview === true) {
-        // When options preview is true the request comes from a livingdocs
-        // editor while a user is editing a document.
-      }
+      // When options preview is true the request comes from a livingdocs
+      // editor while a user is editing a document.
+      const isPreview = options && options.preview === true
 
       // It does not render an unpublished document on the public API
-      if (shouldNotBeRendered(params)) {
+      if (isPreview && paramsAreInsufficient(params)) {
+        // Return undefined if not enough params are provided to
+        // render the include. While editing the draft in the editor
+        // this will just leave the include preview visible.
+        return callback(null, undefined)
+      } else if (shouldNotBeRendered(params)) {
         // Return an empty string to render nothing.
         // While editing the draft in the editor this will remove
         // the include preview.
         return callback(null, '')
-      } else if (paramsAreInsufficient(params)) {
-        // Return undefined in not enough params are provided to
-        // render the include. While editing the draft in the editor
-        // this will just leave the include preview visible.
-        return callback(null, undefined)
       } else {
         // Render the include
         const html = renderInclude(params)
@@ -152,7 +151,7 @@ module.exports = {
 }
 ```
 
-#### Include UI options:
+#### Include UI options:
 
 Use an angular component in the sidebar:
 ```js

--- a/reference-docs/server-extensions/add-custom-include.md
+++ b/reference-docs/server-extensions/add-custom-include.md
@@ -2,67 +2,76 @@
 
 Think of Livingdocs includes as edge-side includes. You can create include components in your design, using a include [directive](../../livingdocs-framework/directives.md).
 Includes can render content to your article or page that comes from an external source.
+Includes are resolved every time a document is rendered. So they can be used to
+display dynamic content that changes after a document has been published.
 
 Displaying a teaser for example can be achieved through includes. An article is referenced and its data (eg. title, description, teaser image) is fetched when rendering a page.
 
-### Example
 
-The server can transform this include:
+## A component with an include directive
+
+Includes are directives on components. They can be used as content placeholders
+that will be filled with HTML created by an include service on the server.
+
+An example component with an include diretive:
 ```html
-<ld-include data-include-service="embed-teaser" data-include-params="{"mediaId":2}"></ld-include>
-```
+<script type="ld-conf">
+  {
+    "name": "embed-teaser",
+    "label": "Article Teaser",
+    "directives": {
+      "embed-teaser": {
+        "service": "embed-teaser"
+      }
+    }
+  }
+</script>
 
-into something like this:
-```html
-<a internal href="/articles/2.html">
-  <div style="background-image: url(https://image.jpg)"></div>
-  <div class="teaser__text">
-      <h3><span>Mathieu Pavageau</span> <span> on Wed May 25 2016</span></h3>
-    <h2>Rocket</h2>
-  </div>
-</a>
-```
-
-### Registration of renderers
-
-Since server `v28.9.0`, you can register includes in the Livingdocs Server using the API exposed by the `li-includes` feature
-
-The include is rendered in two locations:
-- in the editor while editing
-- in the final published HTML
-
-First, create an include component in your design. For example, have a look at the `embed-teaser` in the [timeline design](https://github.com/upfrontIO/livingdocs-design-timeline/blob/master/source/components/Embeds/embed-teaser.html)
-
-```html
 <div doc-include="embed-teaser"></div>
 ```
 
-Each include directive references a `include-service`, that is invoked when rendering the include. The function `render` is called on your custom service:
+## Rendering Options
 
-```js
-exports = module.exports = {
-  render (params, callback) {
-    const renderedHtml = 'hello world!'
-    return callback(null, renderedHtml)
-  }
-}
+Includes can be resolved in two modes when rendering a document. Either a
+`<ld-include>` tag can be rendered so the include can be resolved outside of
+livingdocs (e.g by a script in the browser or a server that delivers the rendered
+html to a browser). Or the includes can be resolved on the livingdocs server in
+the rendering of the document.
+
+#### Unresolved include
+
+An unresolved include looks like this:
+```html
+<div>
+  <ld-include data-include-service="embed-teaser" data-include-params="{"mediaId":2}"></ld-include>
+</div>
 ```
 
-Register a service renderer for the type `embed-teaser`:
+It contains all the information needed to replace it with
+the actual content.
 
-```js
-const includesApi = liServer.features.api('li-includes')
 
-embedTeaserServiceRenderer =
-  require('../../plugins/includes/embed-teaser/service-renderer')
+#### Resolved include
 
-includesApi.registerServiceRenderer(
-  'embed-teaser',
-  embedTeaserServiceRenderer
-)
+If the include is resolved instead of the `<ld-include>` you see the actual HTML
+returned by the include renderer:
+```html
+<div>
+  <a internal href="/articles/2.html">
+    <div style="background-image: url(https://image.jpg)"></div>
+    <div class="teaser__text">
+        <h3><span>Mathieu Pavageau</span> <span> on Wed May 25 2016</span></h3>
+      <h2>Rocket</h2>
+    </div>
+  </a>
+</div>
 ```
 
-Includes are not resolved by default. Enable it in the channel configuration:
+#### How to configure the rendering option
+
+Includes are not resolved by default. Enable it in the
+[channel configuration](../server-configuration/channel-config.md):
+
 ```js
 module.exports = {
 
@@ -78,4 +87,134 @@ module.exports = {
   }
 }
 ```
-If you miss this final step, the rendering will only happen for the includes preview in the editor but NOT in the public API.
+
+
+## Registration of an include renderer in the server
+
+You can register an include renderer in the Livingdocs Server using the API
+of the `li-includes` feature.
+
+The include is rendered in used in two cases:
+
+- in the editor while editing
+- in the rendered HTML if you choose to resolve the include while rendering
+
+So in order to see a preview while editing you have to register an include renderer
+even if you choose not to resolve includes while rendering.
+
+#### Register an include in the server:
+
+Let's register an include renderer for the include `embed-teaser` used in the
+component we defined earlier:
+
+```js
+const includeRenderer = require('../plugins/includes/embed-teaser.js')
+
+const includesApi = liServer.features.api('li-includes')
+includesApi.registerServiceRenderer('embed-teaser', includeRenderer)
+```
+
+`plugins/includes/embed-teaser.js`:
+```js
+module.exports = {
+  name: 'embed-teaser',
+  // The ui configuration is used to configure the user interface
+  // in the editor. See further below for all available options.
+  ui: {
+    type: 'default'
+  },
+  server: {
+    type: 'function',
+    function: function (params, options, callback) {
+      if (options && options.preview === true) {
+        // When options preview is true the request comes from a livingdocs
+        // editor while a user is editing a document.
+      }
+
+      // It does not render an unpublished document on the public API
+      if (shouldNotBeRendered(params)) {
+        // Return an empty string to render nothing.
+        // While editing the draft in the editor this will remove
+        // the include preview.
+        return callback(null, '')
+      } else if (paramsAreInsufficient(params)) {
+        // Return undefined in not enough params are provided to
+        // render the include. While editing the draft in the editor
+        // this will just leave the include preview visible.
+        return callback(null, undefined)
+      } else {
+        // Render the include
+        const html = renderInclude(params)
+        return callback(null, html)
+      }
+    })
+  }
+}
+```
+
+#### Include UI options:
+
+Use an angular component in the sidebar:
+```js
+name: 'embed-teaser',
+ui: {
+  type: 'default'
+}
+```
+
+And this is how you have to register the angular component in the editor
+for the above setting to work.
+```js
+const liEditor = require('@livingdocs/editor')
+liEditor.includes.register('embed-teaser', {
+  template: require('./some-template'),
+  controller: require('./some-controller'),
+  bindings: {
+    directive: '=',
+    component: '=',
+    componentView: '=',
+  }
+})
+```
+
+Use an angular component in a modal:
+```js
+// The ui configuration is used to configure the user interface
+// in the editor.
+ui: {
+  // The angular-modal type selects an angular component to use
+  // in the editor within a popup and allows to configure the button
+  // to open it.
+  type: 'angular-modal',
+  sidebar: {
+    label: 'Assign Teaser to content block',
+    button: 'Link Article'
+  },
+  modal: {
+    label: 'Article Search',
+    component: 'ldEmbedTeaserListIncludeModal'
+  }
+}
+```
+
+Use an external site opened in an iframe in a modal:
+```js
+name: 'ld-giphy',
+ui: {
+  // The angular-modal type selects an angular component to use
+  // in the editor within a popup and allows to configure the button
+  // to open it.
+  type: 'iframe-modal',
+  sidebar: {
+    label: 'Configure Giphy Embed',
+    button: 'Configure'
+  },
+  modal: {
+    label: 'Configure Giphy Embed',
+    url: 'https://rawgit.com/marcbachmann/5f8c957524e967b5aa16cf724c6585e3/raw/586fcd115135ac150ba21b0d776c76a5dad8e3a8/giphy.html'
+  }
+}
+```
+
+Details for the iframe option:
+https://github.com/upfrontIO/livingdocs-editor/pull/1509


### PR DESCRIPTION
## Goals

Document what to return in an include renderer when the params are insufficient so that the editor displays no errors and still displays the preview. Also try to fill in missing parts in the docs and try to clarify the use cases by restructuring the docs.