### PR TITLE
chore(docs): Remove nbsp in Markdown titles

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -6,7 +6,7 @@
 
 * [Glossary](./GLOSSARY.md)
 
-## Videos
+## Videos
 
 * [Livingdocs Design Intro](videos/design_intro.md)
 * [Livingdocs Boilerplate Intro](videos/boilerplate_intro.md)

--- a/concepts/images/image-services.md
+++ b/concepts/images/image-services.md
@@ -74,7 +74,7 @@ Below we'll outline the configuration for both ImgIX and resrc.it.
 
 The ImgIX configuration uses `srcset`. If you don't know about this HTML standard yet, refer to this article first: https://ericportis.com/posts/2014/srcset-sizes/
 
-#### Editor
+#### Editor
 
 ```js
   app: {

--- a/concepts/images/why-an-image-service.md
+++ b/concepts/images/why-an-image-service.md
@@ -16,7 +16,7 @@ If you want to implement another image service refer to the 'Extension' topic be
 
 The image service is stored with each image directive in the json format of livingdocs. The values 'none' or false are not stored, but the imageService member on the directive is simply empty (`undefined`). The setting of the image service happens when a user uploads an image and stays for the lifetime of this image (until another image is uploaded or the image is deleted). The image service that is used to set upon uploading an image is the one with which the editor is started. The image service is constant over the lifetime of a running editor and assigned through an Angular.JS provider at startup time (in `app.coffee`). If the editor 'sees' an imageService it doesn't know (e.g., the editor is started with the service 'resrc.it' and an image is marked to be handled through 'cloudinary') the editor will show an error message to the user and log it.
 
-## Extension
+## Extension
 
 To add a new image service, a developer should familiarize him/herself with the concepts described in the topic 'Solution' as well as the unit tests in `image_service_spec` and `image_service_base_spec` for the general functionality of an image service and `resrcit_image_service_spec` for details of a specific implementation.
 

--- a/reference-docs/common-designs/component_config.md
+++ b/reference-docs/common-designs/component_config.md
@@ -179,7 +179,7 @@ Example:
 Reading example: The `doc-editable` directive `headline` will be filled through the metadata service `iframely` and the content comes from the metadata key `author`.
 
 
-### `doc-image`
+### `doc-image`
 
 `ratios`: allows you to define pre-defined image ratios for an image. The cropping mask in the Livingdocs editor will show those ratios when cropping the image of the respective component.
 

--- a/reference-docs/server-configuration/config.md
+++ b/reference-docs/server-configuration/config.md
@@ -81,7 +81,7 @@ logs: {
 [More info about logging](./logging.md)
 
 
-#### Docker
+#### Docker
 
 This tells the database scripts which recreates the database that docker is used.
 This does not work for docker-compose. And the docker container where postgres runs
@@ -105,7 +105,7 @@ stack: ['all']
 ## Features
 
 
-#### Authentication
+#### Authentication
 
 Configure the authentication feature.
 
@@ -201,7 +201,7 @@ emails: {
 ```
 
 
-#### Designs
+#### Designs
 
 Configure the Livingdocs Design Server.
 
@@ -290,7 +290,7 @@ files: {
 }
 ```
 
-#### Documents
+#### Documents
 
 ```js
 documents: {
@@ -314,7 +314,7 @@ documents: {
 The channel config is described here: [channel config](./channel-config.md)
 
 
-#### Render Pipeline
+#### Render Pipeline
 
 Configure the worker configuration that is used to render Livingdoc Documents.
 

--- a/reference-docs/server-editing-api/README.md
+++ b/reference-docs/server-editing-api/README.md
@@ -6,7 +6,7 @@ Livingdocs provides 2 kinds of REST APIs:
 - A public read-only API that can be [seen here](https://beta.livingdocs.io/public-api.html#/public-api.html)
 - A read/write editing API that requires authentication and can be used to modify documents. This is the API that is used by the Livingdocs editor.
 
-## Editing API
+## Editing API
 
 The editing API is read/write and requires authentication. You can only modify and get documents through the editing API that you own or are associated with through a space (shared account).
 You need knowledge of the editing API when developing features in the core Editor.

--- a/reference-docs/server-print-api/print-api.md
+++ b/reference-docs/server-print-api/print-api.md
@@ -513,7 +513,7 @@ The `getStatus` elements contains the following attributes:
 - `livingdocsId`, the Livingdocs id, should match what you got in the request
 - `statusName`, the print status this article is in, see the available statuses below
 
-#### Available statuses
+#### Available statuses
 
 The available statuses values for a print article are:
 - `Redigieren`, the article is being edited

--- a/reference-docs/server-public-api/public-api.md
+++ b/reference-docs/server-public-api/public-api.md
@@ -1,7 +1,7 @@
 
 # Public Api Documentation
 
-#### Current Version
+#### Current Version
 
 https://beta.livingdocs.io/public-api.html
 

--- a/setup-and-deployment/deployment/container/docker.md
+++ b/setup-and-deployment/deployment/container/docker.md
@@ -174,7 +174,7 @@ Run the container:
 docker run --rm -p 9090:9090 -e "db__host=postgres" -e "search__host=http://elasticsearch:9200" -e "ENVIRONMENT=production" -e "NODE_ENV=production" livingdocs/server node index.js
 ```
 
-### Editor
+### Editor
 
 Build the image:
 ```sh

--- a/setup-and-deployment/npm/publish-packages.md
+++ b/setup-and-deployment/npm/publish-packages.md
@@ -1,4 +1,4 @@
-# Publish npm packages
+# Publish npm packages
 
 All public and private packages belong to the [@livingdocs organization](https://www.npmjs.com/org/livingdocs).
 
@@ -31,7 +31,7 @@ npm adduser --scope=livingdocs --always-auth
 ```
 
 
-### Public package
+### Public package
 
 Packages without a scope are public by default. If you use the `@livingdocs` scope in the package name, you must set access to public explicitly:
 

--- a/videos/design_intro.md
+++ b/videos/design_intro.md
@@ -12,7 +12,7 @@ There is quite some background noise in the video, we are very sorry for this
 
 Learn how to create a Livingdocs Design given that you have already written the HTML and CSS for your intended website.
 
-### Video
+### Video
 
 {% vimeo %}229997156{% endvimeo %}
 

--- a/walkthroughs/add_customizations.md
+++ b/walkthroughs/add_customizations.md
@@ -5,7 +5,7 @@ The boilerplate projects are small customizing setups that illustrate this.
 
 This document gives an overview of how to register custom features without going into detail on how to write any of them.
 
-### Server
+### Server
 
 (Refer to the [boilerplate server](https://github.com/upfrontIO/livingdocs-server-boilerplate) to see real examples of this.)
 


### PR DESCRIPTION
Markdown headings are specified as `#<space+><name>`. This PR changes all `#<nspb><name>` to replace the nbsp with a space in order to have these parsed as titles instead of literal `# foo`.