### PR TITLE
Configure visibility of the Transform Component

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -30,6 +30,7 @@
   * [Design config](reference-docs/common-designs/design_config.md)
 * [Editor config](reference-docs/editor-configuration/editing-features.md)
   * [Toolbar](reference-docs/editor-configuration/editing-features.md#toolbar)
+  * [Properties Panel](reference-docs/editor-configuration/editing-features.md#properties-panel)
   * [Login](reference-docs/editor-configuration/editing-features.md#login)
   * [Dashboard](reference-docs/editor-configuration/editing-features.md#dashboard)
   * [Main menu](reference-docs/editor-configuration/editing-features.md#main-menu)

--- a/reference-docs/editor-configuration/editing-features.md
+++ b/reference-docs/editor-configuration/editing-features.md
@@ -16,6 +16,22 @@ app: {
 }
 ```
 
+## Properties Panel
+
+### Transform Component
+
+Visibility of the "Transform Component" select menu can be configured.
+
+```js
+app: {
+  editor: {
+    propertiesPanel: {
+      transformComponentEnabled: true
+    }
+  }
+}
+```
+
 ## Login
 
 In addition to the Livingdocs login, you can configure additional login providers.


### PR DESCRIPTION
# Changes
Document configuration of _Transform Component_ visibility.

# PM
Issue: upfrontIO/livingdocs-planning#1632
PR: https://github.com/upfrontIO/livingdocs-editor/pull/1793