### PR TITLE
docs: extend transform component configuration

### DIFF
--- a/reference-docs/editor-configuration/editing-features.md
+++ b/reference-docs/editor-configuration/editing-features.md
@@ -26,7 +26,10 @@ Visibility of the "Transform Component" select menu can be configured.
 app: {
   editor: {
     propertiesPanel: {
-      transformComponentEnabled: true
+      transformComponent: {
+        enabled: true,
+        showEvenIfEmpty: false
+      }
     }
   }
 }


### PR DESCRIPTION
## Changelog
We introduce changes in the transform component configuration. Now users can show the transform component dropdown **even** if there is no transformations available.
See: https://github.com/upfrontIO/livingdocs-editor/pull/1862

## Communication
@daut-morina can you review?