### PR TITLE
Data Dashboard v1

### DIFF
--- a/administration/access_rights.md
+++ b/administration/access_rights.md
@@ -35,6 +35,14 @@ Pages:
 - `publishPages`, users that can publish pages
 - `unpublishPages`, users that can unpublish pages
 
+Data:
+
+- `readData`, users that can read data
+- `createData`, users that can create data
+- `writeData`, users that can write data
+- `publishData`, users that can publish data
+- `unpublishData`, users that can unpublish data
+
 Lists (main menu entry):
 
 - `readLists`, users that can read lists

--- a/reference-docs/editor-configuration/editing-features.md
+++ b/reference-docs/editor-configuration/editing-features.md
@@ -99,6 +99,12 @@ app: {
     scope: 'readPages'
   },
   {
+    label: 'Data Records'
+    sref: 'app.dataRecords'
+    icon: 'format-list-checks'
+    scope: 'readDataRecords'
+  },
+  {
     label: 'Lists',
     sref: 'app.lists',
     icon: 'view-headline',

--- a/reference-docs/editor-configuration/search-filters.md
+++ b/reference-docs/editor-configuration/search-filters.md
@@ -19,6 +19,10 @@ The editor core API exposes functions to customize the search filters on the das
 
   This configures the pages screen.
 
+- `dataRecordList`
+
+  This configures the data-record screen.
+
 - `documentListList`
 
   This configures the List screen.
@@ -55,6 +59,13 @@ filters: {
     displayFilters: [],
     defaultQueries: [
       {type: 'documentType', value: 'page'},
+      {type: 'sortBy', value: '-updated_at'}
+    ]
+  },
+  dataRecordList: {
+    displayFilters: ['timeRange'],
+    defaultQueries: [
+      {type: 'documentType', value: 'data-record'},
       {type: 'sortBy', value: '-updated_at'}
     ]
   },


### PR DESCRIPTION
Server PR https://github.com/upfrontIO/livingdocs-server/pull/1879

# Description

This PR adds the documentation of the new scopes, menues and filters needed for the new document-type `data`.