### PR TITLE
docs: multiply auth connections toggle flags

### DIFF
--- a/reference-docs/server-configuration/config.md
+++ b/reference-docs/server-configuration/config.md
@@ -129,6 +129,8 @@ auth: {
     local: {
       label: 'Password',
       enabled: true,
+      loginEnabled: true,
+      registrationEnabled: true,
       strategy: 'li-authentication-local',
       config: {
         default_login_domain: 'upfront.io',
@@ -333,7 +335,7 @@ files: {
 ```js
 documents: {
   imageServices: {
-    imgix: {} // imageService specific configuration 
+    imgix: {} // imageService specific configuration
   }
 }
 ```

--- a/reference-docs/server-configuration/single_sign-on.md
+++ b/reference-docs/server-configuration/single_sign-on.md
@@ -19,6 +19,8 @@ In the following example we set three different providers: Github, Google and Fa
       github: {
         strategy: 'li-authentication-sso',
         enabled: true,
+        loginEnabled: true,
+        registrationEnabled: true,
         connectionId: 'github',
         config: {
           scope: 'user:email',
@@ -33,6 +35,8 @@ In the following example we set three different providers: Github, Google and Fa
       google: {
         strategy: 'li-authentication-sso',
         enabled: true,
+        loginEnabled: true,
+        registrationEnabled: true,
         connectionId: 'google',
         config: {
           scope: 'email',
@@ -48,6 +52,8 @@ In the following example we set three different providers: Github, Google and Fa
       facebook: {
         strategy: 'li-authentication-sso',
         enabled: true,
+        loginEnabled: true,
+        registrationEnabled: true,
         connectionId: 'facebook',
         config: {
           scope: 'email',


### PR DESCRIPTION
## Planning
https://github.com/upfrontIO/livingdocs-planning/issues/2011

## Changelog
Auth configuration before:
```
auth: {
  connections: {
    foo: {
      enabled: true
    }
  }
}
```
Auth configuration after:
```
auth: {
  connections: {
    foo: {
      enabled: true,
      loginEnabled: true,
      registrationEnabled: true,
    }
  }
}
```